### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ e.g.
 
 ### wrapper-version
 
-Displays the current version of the Wrapper Script.
+Displays the current version of the wrapper script.
 
 e.g.
 


### PR DESCRIPTION
"wrapper script" is not a proper noun.