### PR TITLE
Fixed yaml.load() warning

### DIFF
--- a/moleculew
+++ b/moleculew
@@ -515,7 +515,7 @@ for filename in os.listdir(molecule_dir):
 
     with open(molecule_yaml, 'r') as stream:
         try:
-            contents = yaml.load(stream)
+            contents = yaml.safe_load(stream)
         except yaml.YAMLError as exc:
             continue
 


### PR DESCRIPTION
```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```

Changed to use `yaml.safe_load()`.