### PR TITLE
Dropped docker-lib configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,24 +55,20 @@ You can run any Molecule command directly using the wrapper e.g.:
 ```
 
 By default Molecule Wrapper runs using the latest versions of Python 2.x,
-Ansible, the Python Docker library and Molecule.
+Ansible and Molecule.
 
-You can also specify particular versions of Python, Ansible, the Python Docker
-library and Molecule by passing command line arguments or setting environment
-variables:
+You can also specify particular versions of Python, Ansible and Molecule by
+passing command line arguments or setting environment variables:
 
 ```
 Additional options:
   --ansible VERSION          Use the specified version of Ansible
-  --docker-lib VERSION       Use the specified version of the Python Docker
-                             library
   --molecule VERSION         Use the specified version of Molecule
   --python VERSION           Use the specified version of Python
   --use-system-dependencies  Use system dependencies
 
 Environment variables:
   MOLECULEW_ANSIBLE     Use the specified version of Ansible
-  MOLECULEW_DOCKER_LIB  Use the specified version of the Python Docker library
   MOLECULEW_MOLECULE    Use the specified version of Molecule
   MOLECULEW_PYTHON      Use the specified version of Python
   MOLECULEW_USE_SYSTEM  Use system dependencies (true/false)
@@ -145,15 +141,12 @@ Displays the current dependency versions being used:
 ```
 Options:
   --ansible VERSION          Use the specified version of Ansible
-  --docker-lib VERSION       Use the specified version of the Python Docker
-                             library
   --molecule VERSION         Use the specified version of Molecule
   --python VERSION           Use the specified version of Python
   --use-system-dependencies  Use the system version of Python
 
 Environment variables:
   MOLECULEW_ANSIBLE     Use the specified version of Ansible
-  MOLECULEW_DOCKER_LIB  Use the specified version of the Python Docker library
   MOLECULEW_MOLECULE    Use the specified version of Molecule
   MOLECULEW_PYTHON      Use the specified version of Python
   MOLECULEW_USE_SYSTEM  Use system dependencies (true/false)
@@ -181,15 +174,12 @@ Freezes the dependency versions being used:
 ```
 Options:
   --ansible VERSION          Use the specified version of Ansible
-  --docker-lib VERSION       Use the specified version of the Python Docker
-                             library
   --molecule VERSION         Use the specified version of Molecule
   --python VERSION           Use the specified version of Python
   --use-system-dependencies  Use the system version of Python
 
 Environment variables:
   MOLECULEW_ANSIBLE     Use the specified version of Ansible
-  MOLECULEW_DOCKER_LIB  Use the specified version of the Python Docker library
   MOLECULEW_MOLECULE    Use the specified version of Molecule
   MOLECULEW_PYTHON      Use the specified version of Python
   MOLECULEW_USE_SYSTEM  Use system dependencies (true/false)
@@ -281,15 +271,12 @@ from the Molecule output.
 ```
 Options:
   --ansible VERSION          Use the specified version of Ansible
-  --docker-lib VERSION       Use the specified version of the Python Docker
-                             library
   --molecule VERSION         Use the specified version of Molecule
   --python VERSION           Use the specified version of Python
   --use-system-dependencies  Use the system version of Python
 
 Environment variables:
   MOLECULEW_ANSIBLE     Use the specified version of Ansible
-  MOLECULEW_DOCKER_LIB  Use the specified version of the Python Docker library
   MOLECULEW_MOLECULE    Use the specified version of Molecule
   MOLECULEW_PYTHON      Use the specified version of Python
   MOLECULEW_USE_SYSTEM  Use system dependencies (true/false)
@@ -319,15 +306,12 @@ Displays the location of the Virtualenv environment.
 ```
 Options:
   --ansible VERSION          Use the specified version of Ansible
-  --docker-lib VERSION       Use the specified version of the Python Docker
-                             library
   --molecule VERSION         Use the specified version of Molecule
   --python VERSION           Use the specified version of Python
   --use-system-dependencies  Use the system version of Python
 
 Environment variables:
   MOLECULEW_ANSIBLE     Use the specified version of Ansible
-  MOLECULEW_DOCKER_LIB  Use the specified version of the Python Docker library
   MOLECULEW_MOLECULE    Use the specified version of Molecule
   MOLECULEW_PYTHON      Use the specified version of Python
   MOLECULEW_USE_SYSTEM  Use system dependencies (true/false)

--- a/moleculew
+++ b/moleculew
@@ -33,14 +33,12 @@ WRAPPER_VERSION=0.9.11-dev
 VERSION_DIR='.moleculew'
 PYTHON_VERSION_FILE="$VERSION_DIR/python_version"
 ANSIBLE_VERSION_FILE="$VERSION_DIR/ansible_version"
-DOCKER_LIB_VERSION_FILE="$VERSION_DIR/docker_lib_version"
 MOLECULE_VERSION_FILE="$VERSION_DIR/molecule_version"
 
 BUILD_DEPENDENCIES_INSTALLLED=false
 PYENV_INSTALLED=false
 
 ANSIBLE_VERSION=''
-DOCKER_LIB_VERSION=''
 MOLECULE_VERSION=''
 PYTHON_VERSION=''
 USE_SYSTEM_DEPENDENCIES=false
@@ -240,15 +238,9 @@ install_ansible() {
     echo ''
 }
 
-install_docker_lib() {
-    banner "Installing Python Docker $DOCKER_LIB_VERSION into virtualenv $VIRTUAL_ENV"
-    pip install "docker==$DOCKER_LIB_VERSION"
-    echo ''
-}
-
 install_molecule() {
     banner "Installing Molecule $MOLECULE_VERSION into virtualenv $VIRTUAL_ENV"
-    pip install "molecule==$MOLECULE_VERSION"
+    pip install "molecule[docker]==$MOLECULE_VERSION"
     echo ''
 }
 
@@ -290,7 +282,6 @@ wrapper_version() {
 print_versions() {
     echo "Python: $PYTHON_VERSION"
     echo "Ansible: $ANSIBLE_VERSION"
-    echo "Python Docker library: $DOCKER_LIB_VERSION"
     echo "Molecule: $MOLECULE_VERSION"
 }
 
@@ -310,7 +301,6 @@ wrapper_freeze() {
 
     echo "$PYTHON_VERSION" > "$PYTHON_VERSION_FILE"
     echo "$ANSIBLE_VERSION" > "$ANSIBLE_VERSION_FILE"
-    echo "$DOCKER_LIB_VERSION" > "$DOCKER_LIB_VERSION_FILE"
     echo "$MOLECULE_VERSION" > "$MOLECULE_VERSION_FILE"
 
     print_versions
@@ -327,9 +317,6 @@ wrapper_unfreeze() {
     if [[ -f "$ANSIBLE_VERSION_FILE" ]]; then
         rm --verbose "$ANSIBLE_VERSION_FILE"
     fi
-    if [[ -f "$DOCKER_LIB_VERSION_FILE" ]]; then
-        rm --verbose "$DOCKER_LIB_VERSION_FILE"
-    fi
     if [[ -f "$MOLECULE_VERSION_FILE" ]]; then
         rm --verbose "$MOLECULE_VERSION_FILE"
     fi
@@ -343,12 +330,10 @@ wrapper_upgrade_versions() {
 
     local CURRENT_PYTHON_VERSION="$PYTHON_VERSION"
     local CURRENT_ANSIBLE_VERSION="$ANSIBLE_VERSION"
-    local CURRENT_DOCKER_LIB_VERSION="$DOCKER_LIB_VERSION"
     local CURRENT_MOLECULE_VERSION="$MOLECULE_VERSION"
 
     query_latest_python_version2
     query_latest_package_version ANSIBLE_VERSION ansible
-    query_latest_package_version DOCKER_LIB_VERSION docker
     query_latest_package_version MOLECULE_VERSION molecule
     echo ''
 
@@ -363,12 +348,6 @@ wrapper_upgrade_versions() {
         echo "Ansible: $CURRENT_ANSIBLE_VERSION (no change)"
     else
         echo "Ansible: $CURRENT_ANSIBLE_VERSION -> $ANSIBLE_VERSION"
-    fi
-
-    if [[ "$CURRENT_DOCKER_LIB_VERSION" == "$DOCKER_LIB_VERSION" ]]; then
-        echo "Python Docker library: $CURRENT_DOCKER_LIB_VERSION (no change)"
-    else
-        echo "Python Docker library: $CURRENT_DOCKER_LIB_VERSION -> $DOCKER_LIB_VERSION"
     fi
 
     if [[ "$CURRENT_MOLECULE_VERSION" == "$MOLECULE_VERSION" ]]; then
@@ -391,8 +370,6 @@ Molecule Wrapper
 
 Additional options:
   --ansible VERSION          Use the specified version of Ansible
-  --docker-lib VERSION       Use the specified version of the Python Docker
-                             library
   --molecule VERSION         Use the specified version of Molecule
   --python VERSION           Use the specified version of Python
   --use-system-dependencies  Use system dependencies
@@ -445,11 +422,6 @@ query_package_versions() {
 wrapper_options_ansible() {
     echo 'latest'
     query_package_versions 'ansible' '2.7'
-}
-
-wrapper_options_docker_lib() {
-    echo 'latest'
-    query_package_versions 'docker' '3.0'
 }
 
 wrapper_options_molecule() {
@@ -574,15 +546,6 @@ parse_args() {
                 ANSIBLE_VERSION="$1"
                 shift
             ;;
-            --docker-lib=*)
-                DOCKER_LIB_VERSION="${1#*=}"
-                shift
-            ;;
-            --docker-lib)
-                shift
-                DOCKER_LIB_VERSION="$1"
-                shift
-            ;;
             --molecule=*)
                 MOLECULE_VERSION="${1#*=}"
                 shift
@@ -635,9 +598,6 @@ detemine_versions() {
     if [[ $ANSIBLE_VERSION == '' ]]; then
         ANSIBLE_VERSION="$MOLECULEW_ANSIBLE"
     fi
-    if [[ $DOCKER_LIB_VERSION == '' ]]; then
-        DOCKER_LIB_VERSION="$MOLECULEW_DOCKER_LIB"
-    fi
     if [[ $MOLECULE_VERSION == '' ]]; then
         MOLECULE_VERSION="$MOLECULEW_MOLECULE"
     fi
@@ -672,17 +632,6 @@ detemine_versions() {
         query_latest_package_version ANSIBLE_VERSION ansible
     fi
 
-    if [[ $DOCKER_LIB_VERSION == '' ]] || [[ $DOCKER_LIB_VERSION == 'default' ]]; then
-        if [[ -f $DOCKER_LIB_VERSION_FILE ]]; then
-            DOCKER_LIB_VERSION=$(<"$DOCKER_LIB_VERSION_FILE")
-        fi
-        if [[ $DOCKER_LIB_VERSION == '' ]]; then
-            query_latest_package_version DOCKER_LIB_VERSION docker
-        fi
-    elif [[ $DOCKER_LIB_VERSION == 'latest' ]]; then
-        query_latest_package_version DOCKER_LIB_VERSION docker
-    fi
-
     if [[ $MOLECULE_VERSION == '' ]] || [[ $MOLECULE_VERSION == 'default' ]]; then
         if [[ -f $MOLECULE_VERSION_FILE ]]; then
             MOLECULE_VERSION=$(<$MOLECULE_VERSION_FILE)
@@ -698,9 +647,9 @@ detemine_versions() {
 activate_virtualenv() {
     detemine_versions
 
-    MOLECULE_WRAPPER_ENV="$HOME/.moleculew/molecule/$MOLECULE_VERSION/ansible/$ANSIBLE_VERSION/python/$PYTHON_VERSION/docker/$DOCKER_LIB_VERSION"
+    MOLECULE_WRAPPER_ENV="$HOME/.moleculew/molecule/$MOLECULE_VERSION/ansible/$ANSIBLE_VERSION/python/$PYTHON_VERSION"
 
-    if [ ! -d "$MOLECULE_WRAPPER_ENV" ]; then
+    if [ ! -f "$MOLECULE_WRAPPER_ENV/bin/activate" ]; then
 
         build_dependencies_present
 
@@ -717,8 +666,6 @@ activate_virtualenv() {
         echo ''
 
         install_ansible
-
-        install_docker_lib
 
         install_molecule
     else
@@ -744,9 +691,6 @@ case $MOLECULE_CMD in
     ;;
     wrapper-options-ansible)
         wrapper_options_ansible
-    ;;
-    wrapper-options-docker-lib)
-        wrapper_options_docker_lib
     ;;
     wrapper-options-molecule)
         wrapper_options_molecule

--- a/zsh/moleculew.plugin.zsh
+++ b/zsh/moleculew.plugin.zsh
@@ -198,10 +198,6 @@ __moleculew_ansible_options() {
     compadd -V version -- $(./moleculew wrapper-options-ansible)
 }
 
-__moleculew_docker_lib_options() {
-    compadd -V version -- $(./moleculew wrapper-options-docker-lib)
-}
-
 __moleculew_molecule_options() {
     compadd -V version -- $(./moleculew wrapper-options-molecule)
 }
@@ -225,7 +221,6 @@ _moleculew() {
 
     wrapper_args=(
         "($I)--ansible[The version of Ansible to use.]:ansible_versions:__moleculew_ansible_options"
-        "($I)--docker-lib[The version of the Python Docker library to use.]:docker_lib_versions:__moleculew_docker_lib_options"
         "($I)--molecule[The version of Molecule to use.]:molecule_versions:__moleculew_molecule_options"
         "($I --use-system-dependencies)--python[The version of Python to use.]:python_versions:__moleculew_python_options"
         "($I --python)--use-system-dependencies[Use system dependencies.]"


### PR DESCRIPTION
Use the Molecule `docker` extra dependencies instead.