### PR TITLE
Added tab-completion for linters and Testinfra versions

### DIFF
--- a/zsh/moleculew.plugin.zsh
+++ b/zsh/moleculew.plugin.zsh
@@ -210,6 +210,22 @@ __moleculew_python_options() {
     compadd -V version -- $(./moleculew wrapper-options-python)
 }
 
+__moleculew_yamllint_options() {
+    compadd -V version -- $(./moleculew wrapper-options-yamllint)
+}
+
+__moleculew_ansible_lint_options() {
+    compadd -V version -- $(./moleculew wrapper-options-ansible-lint)
+}
+
+__moleculew_flake8_options() {
+    compadd -V version -- $(./moleculew wrapper-options-flake8)
+}
+
+__moleculew_testinfra_options() {
+    compadd -V version -- $(./moleculew wrapper-options-testinfra)
+}
+
 _moleculew() {
     if [[ ! -f ./moleculew ]] && [[ ! $commands[molecule] ]]; then
         _message -r 'moleculew not found' && return 1
@@ -227,6 +243,10 @@ _moleculew() {
         "($I)--ansible[The version of Ansible to use.]:ansible_versions:__moleculew_ansible_options"
         "($I)--docker-lib[The version of the Python Docker library to use.]:docker_lib_versions:__moleculew_docker_lib_options"
         "($I)--molecule[The version of Molecule to use.]:molecule_versions:__moleculew_molecule_options"
+        "($I)--yamllint[The version of YamlLint to use.]:yamllint_versions:__moleculew_yamllint_options"
+        "($I)--ansible-lint[The version of Ansible Lint to use.]:ansible_lint_versions:__moleculew_ansible_lint_options"
+        "($I)--flake8[The version of Flake8 to use.]:flake8_versions:__moleculew_flake8_options"
+        "($I)--testinfra[The version of Testinfra to use.]:testinfra_versions:__moleculew_testinfra_options"
         "($I --use-system-dependencies)--python[The version of Python to use.]:python_versions:__moleculew_python_options"
         "($I --python)--use-system-dependencies[Use system dependencies.]"
     )


### PR DESCRIPTION
So you can more easily specify the versions.