### PR TITLE
Increased minimum Testinfra version to 5.3.1

### DIFF
--- a/moleculew
+++ b/moleculew
@@ -569,7 +569,7 @@ wrapper_options_flake8() {
 
 wrapper_options_testinfra() {
     echo 'latest'
-    query_package_versions 'testinfra' '5.2.2'
+    query_package_versions 'testinfra' '5.3.1'
 }
 
 wrapper_options_scenario() {


### PR DESCRIPTION
Keeping up with the latest changes.